### PR TITLE
Support gpu_merkle for prove_with_commitment_async

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -308,12 +308,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "futures"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b147ee9d1f6d097cef9ce628cd2ee62288d963e16fb287bd9286455b241382d"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
 name = "futures-channel"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07bbe89c50d7a535e539b8c17bc0b49bdb77747034daa8087407d655f3f7cc1d"
 dependencies = [
  "futures-core",
+ "futures-sink",
 ]
 
 [[package]]
@@ -323,10 +339,61 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
 
 [[package]]
+name = "futures-executor"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baf29c38818342a3b26b5b923639e7b1f4a61fc5e76102d4b1981c6dc7a7579d"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-io"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
+
+[[package]]
+name = "futures-macro"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "futures-sink"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c39754e157331b013978ec91992bde1ac089843443c49cbc7f46150b0fad0893"
+
+[[package]]
+name = "futures-task"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
+
+[[package]]
+name = "futures-util"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-io",
+ "futures-macro",
+ "futures-sink",
+ "futures-task",
+ "memchr",
+ "pin-project-lite",
+ "slab",
+]
 
 [[package]]
 name = "getrandom"
@@ -639,6 +706,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
+name = "pin-project-lite"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
+
+[[package]]
 name = "plonky2"
 version = "1.1.0"
 source = "git+https://github.com/InternetMaximalism/polygon-plonky2.git?branch=main#940ce7319a01f683b1cc55664e40e31cd882bee1"
@@ -687,6 +760,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "env_logger",
+ "futures",
  "hashbrown 0.14.5",
  "hex",
  "itertools 0.12.1",
@@ -959,6 +1033,12 @@ name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+
+[[package]]
+name = "slab"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
 name = "spin"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,14 @@ hashbrown = "0.14.5"
 env_logger = "0.11.3"
 log = "0.4.21"
 tiny-keccak = "2.0.2"
+futures = { version = "0.3", optional = true }
 
 [features]
 not-constrain-keccak = []
+# Bridges the sync `SimpleGenerator::run_once` to starky's async
+# `prove_with_commitment_async` via `futures::executor::block_on`. Required when
+# the host enables `starky/gpu_merkle` on `wasm32` — otherwise starky's sync
+# `prove_with_commitment` panics ("Stark prover must be awaited on wasm with
+# gpu_merkle enabled"). On native or without `starky/gpu_merkle`, the sync path
+# is used as before.
+gpu_merkle = ["dep:futures"]

--- a/src/keccak_stark/prover.rs
+++ b/src/keccak_stark/prover.rs
@@ -11,9 +11,14 @@ use starky::{
     config::StarkConfig,
     cross_table_lookup::{get_ctl_data, CrossTableLookup, TableWithColumns},
     proof::StarkProofWithMetadata,
-    prover::prove_with_commitment,
     stark::Stark,
 };
+#[cfg(not(all(feature = "gpu_merkle", target_arch = "wasm32")))]
+use starky::prover::prove_with_commitment;
+#[cfg(all(feature = "gpu_merkle", target_arch = "wasm32"))]
+use starky::prover::prove_with_commitment_async;
+#[cfg(all(feature = "gpu_merkle", target_arch = "wasm32"))]
+use futures::executor::block_on;
 
 use super::keccak_stark::{
     ctl_data_inputs, ctl_data_outputs, ctl_filter_inputs, ctl_filter_outputs,
@@ -80,6 +85,25 @@ where
     // plonky2 1.x: prove_with_commitment grew two extra args
     // (final_poly_coeff_len, max_num_query_steps) for verifier-circuit FRI
     // pinning. We don't pin to a specific verifier circuit here, so pass None.
+    //
+    // wasm32 + gpu_merkle: starky's sync `prove_with_commitment` panics; the
+    // async variant resolves via wgpu's blocking queue poll inside a Web
+    // Worker, so `block_on` is safe in that environment.
+    #[cfg(all(feature = "gpu_merkle", target_arch = "wasm32"))]
+    let proof = block_on(prove_with_commitment_async(
+        stark,
+        config,
+        trace,
+        &trace_commitment,
+        Some(&ctl_data[0]),
+        Some(&ctl_challenges),
+        &mut challenger,
+        public_inputs,
+        None,
+        None,
+        timing,
+    ))?;
+    #[cfg(not(all(feature = "gpu_merkle", target_arch = "wasm32")))]
     let proof = prove_with_commitment(
         stark,
         config,


### PR DESCRIPTION
## Context
`intmax3-zkp` used to call `https://github.com/lita-xyz/plonky2_keccak.git` but now is calling `https://github.com/InternetMaximalism/plonky2_keccak.git` which does not have gpu_merkle feature unlike `lita-xyz` package. 

## Summary

- Adds a `gpu_merkle` cargo feature that swit
- ches the keccak STARK prover to starky's async `prove_with_commitment_async` when targeting `wasm32`, so hosts that enable `starky/gpu_merkle` no longer panic during proving.
- Native builds and any build without `gpu_merkle` keep the existing sync `prove_with_commitment` path — zero behavior change off the new feature.

## Changes

### 1. New optional `gpu_merkle` feature and `futures` dep (`Cargo.toml`, `Cargo.lock`)

- Declares `futures = { version = "0.3", optional = true }` and a `gpu_merkle = ["dep:futures"]` feature so `futures` is only pulled in when callers explicitly opt into the GPU-merkle path.
- Needed because the async prover returns a `Future` that has to be driven from the sync `SimpleGenerator::run_once` boundary; `futures::executor::block_on` is the smallest dependency that does that, and gating it behind a feature avoids forcing the executor on consumers who don't need it.
- Without this, every consumer would pay for `futures-executor` even on native builds where the sync path is fine.

### 2. Bridge sync generator to async prover on `wasm32 + gpu_merkle` (`src/keccak_stark/prover.rs`)

- Splits the `prove_with_commitment` call site with `#[cfg(all(feature = "gpu_merkle", target_arch = "wasm32"))]`: that target uses `block_on(prove_with_commitment_async(..))`, every other target keeps the existing sync call.
- Required because starky's sync `prove_with_commitment` panics with *"Stark prover must be awaited on wasm with gpu_merkle enabled"* once the host turns on `starky/gpu_merkle` — the GPU Merkle build only exposes a usable code path through the async API.
- The `cfg` is intentionally narrow (`wasm32` **and** `gpu_merkle`): on native, `block_on` would deadlock against a real async runtime, and without `gpu_merkle` the sync path is still correct and avoids dragging the executor into the call graph.
- Inline comment documents why `block_on` is safe here: in the wasm + gpu_merkle deployment the future resolves via wgpu's blocking queue poll inside a Web Worker, so blocking the worker thread is the intended waiting strategy.

## Context

`SimpleGenerator::run_once` (the entry point plonky2 calls when filling witnesses) is sync, so the keccak prover has historically called starky's sync `prove_with_commitment`. starky's `gpu_merkle` build replaces the CPU Merkle commitment with a wgpu-backed implementation whose only correct entry point is async — calling the sync wrapper trips an explicit `panic!` in starky.

Hosts running this crate inside a Web Worker with `starky/gpu_merkle` enabled therefore can't prove at all today. This PR threads the async variant through just for that configuration while keeping every other build (native, wasm without `gpu_merkle`, native with `gpu_merkle`) on the original sync path. `futures::executor::block_on` is acceptable specifically because the wasm worker is the thread that owns the wgpu queue poll loop, so the future *will* make progress while the worker blocks.

## Test Plan

- [x] `cargo build` (default features) — confirm no `futures` dep is pulled in and the sync path still compiles.
- [x] `cargo build --features gpu_merkle` on native — verify the `cfg` correctly excludes the async branch (sync path still selected).
- [x] `cargo build --target wasm32-unknown-unknown --features gpu_merkle` with `starky/gpu_merkle` enabled in the host — verify the async branch is selected and the build succeeds.
- [x] End-to-end: run a keccak proof inside the consuming wasm host (Web Worker, `starky/gpu_merkle` on) and confirm the previous *"Stark prover must be awaited on wasm with gpu_merkle enabled"* panic is gone and the proof verifies.
- [ ] `cargo test` on native — existing prover/verifier tests continue to pass.

## Remaining

- [x] Confirm the consuming wasm host actually enables `gpu_merkle` on this crate (not just on `starky`) so the new cfg activates.
- [ ] Decide whether to expose the async prover directly (returning a `Future` from a new `prove_async`) so callers can await instead of `block_on`-ing — out of scope here, but worth revisiting if more async paths land.
